### PR TITLE
Support LDFLAGS overriden

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -24,7 +24,7 @@ CFLAGS		=	$(WFLAGS) $(DEFINES) $(INC)
 SOURCES		=	dislocker.c common.c sectors.c \
 			config.c xstd/xstdio.c xstd/xstdlib.c
 OBJECTS		=	$(SOURCES:.c=.o)
-LDFLAGS		=	$(LIB) -lpthread -lpolarssl
+override LDFLAGS		+=	$(LIB) -lpthread -lpolarssl
 BIN		=	$(PROGNAME)
 
 EXT_OBJ		=	metadata/datums.o metadata/metadata.o metadata/vmk.o metadata/fvek.o metadata/extended_info.o \


### PR DESCRIPTION
Fedora need to secure the linking by passing -Wl,-z,relro to the ldflags, however this will break the linking if we use LDFLAGS="-Wl,-z,relro" directly. In order to add these 3 flags into LDFLAGS, override variable is needed.
