### PR TITLE
Replace polarssl with mbedtls

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -14,9 +14,9 @@ You need:
  - A partition encrypted with BitLocker, from Windows Vista, 7 or 8.
 
 For Debian-like:
-  aptitude install libfuse-dev libpolarssl-dev
+  aptitude install libfuse-dev libmbedtls-dev
 For Fedora-like:
-  yum install fuse-devel polarssl-devel
+  yum install fuse-devel mbedtls-devel
 For OSX: Follow the instructions in the next section.
 
 Of course, you also need a compiler like gcc or clang, and make.
@@ -38,7 +38,7 @@ This will install dislocker.
 
 . If you're on FreeBSD, run the following commands for installing the required
 libraries:
-$ pkg install polarssl gmake fusefs-libs
+$ pkg install mbedtls gmake fusefs-libs
 Then follow the instructions below (next point) by replacing `make' with
 `gmake':
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -18,7 +18,7 @@ DEFINES		=	-DPROGNAME=\"$(PROGNAME)\" -DVERSION=\"$(VERSION)\" -D_FILE_OFFSET_BI
 DEFINES		+=	-DAUTHOR="$(AUTHOR)" -D__OS=\"$(OS)\" -D__ARCH=\"$(ARCH)\"
 DEFINES		+=	-D__ARCH_$(shell echo $(ARCH) | tr a-z A-Z) -D__$(shell echo $(OS) | tr a-z A-Z)
 INC		=	-I. -I/usr/local/include
-LIB		=	-lpthread -lpolarssl -L. -L/usr/local/lib
+LIB		=	-lpthread -lmbedtls -L. -L/usr/local/lib
 CHARDEN		=	-fstack-protector -fPIC -D_FORTIFY_SOURCE=2 -O1
 LHARDEN		=	-pie -fPIE
 WFLAGS		=	-Wall -Werror -Wextra
@@ -186,10 +186,10 @@ clean:
 travis-install:
 	if [ "$$TRAVIS_OS_NAME" = "linux" ]; then                     \
 		sudo apt-get update -qq;                              \
-		sudo apt-get install -qq libfuse-dev libpolarssl-dev; \
+		sudo apt-get install -qq libfuse-dev libmbedtls-dev; \
 	elif [ "$$TRAVIS_OS_NAME" = "osx" ]; then                     \
 		brew update;                                          \
-		brew install polarssl;                                \
+		brew install mbedtls;                                \
 		brew install osxfuse;                                 \
 	fi
 	make CC=$(CC)

--- a/src/accesses/bek/bekfile.c
+++ b/src/accesses/bek/bekfile.c
@@ -176,7 +176,7 @@ int get_vmk_from_bekfile(bitlocker_dataset_t* dataset, dis_config_t* cfg, void**
 	
 	xprintf(L_INFO, "Key datum found and payload extracted!\n");
 	
-	result = get_vmk((datum_aes_ccm_t*)*vmk_datum, recovery_key, rk_size, (datum_key_t**)vmk_datum);
+	result = get_vmk((datum_mbedtls_aes_ccm_t*)*vmk_datum, recovery_key, rk_size, (datum_key_t**)vmk_datum);
 	
 	xfree(recovery_key);
 	

--- a/src/accesses/rp/recovery_password.c
+++ b/src/accesses/rp/recovery_password.c
@@ -122,7 +122,7 @@ int get_vmk_from_rp(bitlocker_dataset_t* dataset, dis_config_t* cfg, void** vmk_
 	cfg->recovery_password = NULL;
 	
 	/* As the computed key length is always the same, use a direct value */
-	result = get_vmk((datum_aes_ccm_t*)aesccm_datum, recovery_key, 32, (datum_key_t**)vmk_datum);
+	result = get_vmk((datum_mbedtls_aes_ccm_t*)aesccm_datum, recovery_key, 32, (datum_key_t**)vmk_datum);
 	
 	xfree(recovery_key);
 	

--- a/src/accesses/stretch_key.h
+++ b/src/accesses/stretch_key.h
@@ -26,12 +26,8 @@
 
 #include "common.h"
 
-#include "polarssl/config.h"
-#if defined(POLARSSL_SHA256_C)
-#include "polarssl/sha256.h"
-#else
-#include "polarssl/sha2.h"
-#endif
+#include "mbedtls/config.h"
+#include "mbedtls/sha256.h"
 
 #include "ssl_bindings.h"
 

--- a/src/accesses/user_pass/Makefile
+++ b/src/accesses/user_pass/Makefile
@@ -17,7 +17,7 @@ CHARDEN		=	-fstack-protector -fPIC -D_FORTIFY_SOURCE=2 -O1
 LHARDEN		=	-pie -fPIE -Wl,-z,relro -Wl,-z,now
 WFLAGS		=	-Wall -Werror -Wextra
 CFLAGS		=	$(WFLAGS) $(DEFINES) $(INC) $(CHARDEN)
-override LDFLAGS    +=	$(LIB) $(LHARDEN) -lpolarssl
+override LDFLAGS    +=	$(LIB) $(LHARDEN) -lmbedtls
 MAIN_OBJECT	=	
 SOURCES		=	user_pass.c ../stretch_key.c
 OBJECTS		=	$(SOURCES:.c=.o) ../stretch_key.o \

--- a/src/accesses/user_pass/user_pass.c
+++ b/src/accesses/user_pass/user_pass.c
@@ -130,7 +130,7 @@ int get_vmk_from_user_pass(bitlocker_dataset_t* dataset, dis_config_t* cfg, void
 	cfg->user_password = NULL;
 	
 	/* As the computed key length is always the same, use a direct value */
-	return get_vmk((datum_aes_ccm_t*)aesccm_datum, user_hash, 32, (datum_key_t**)vmk_datum);;
+	return get_vmk((datum_mbedtls_aes_ccm_t*)aesccm_datum, user_hash, 32, (datum_key_t**)vmk_datum);;
 }
 
 

--- a/src/dislocker.rb
+++ b/src/dislocker.rb
@@ -10,7 +10,7 @@ class Dislocker < Formula
   sha1 "d05858bd9d5d5fc0f21fef3ed6fa32bea13be762"
   version "0.4.0"
 
-  depends_on "polarssl"
+  depends_on "mbedtls"
   depends_on "osxfuse"
 
   def install

--- a/src/encommon.h
+++ b/src/encommon.h
@@ -31,7 +31,7 @@
 #include "metadata/extended_info.h"
 
 
-#include "polarssl/aes.h"
+#include "mbedtls/aes.h"
 #include "ssl_bindings.h"
 
 
@@ -43,7 +43,7 @@
  * @see encryption/decrypt.c
  * @see encryption/encrypt.c
  */
-typedef struct _aes_contexts {
+typedef struct _mbedtls_aes_contexts {
 	AES_CONTEXT FVEK_E_ctx;
 	AES_CONTEXT FVEK_D_ctx;
 	

--- a/src/encryption/decrypt.c
+++ b/src/encryption/decrypt.c
@@ -31,7 +31,7 @@
 /*
  * Two functions used by decrypt_key
  */
-static int aes_ccm_encrypt_decrypt(
+static int mbedtls_aes_ccm_encrypt_decrypt(
 					AES_CONTEXT* ctx,
 					unsigned char* iv, unsigned char iv_length,
 					unsigned char* input, unsigned int input_length,
@@ -39,7 +39,7 @@ static int aes_ccm_encrypt_decrypt(
 					unsigned char* output
 						   );
 
-static int aes_ccm_compute_unencrypted_tag(
+static int mbedtls_aes_ccm_compute_unencrypted_tag(
 									AES_CONTEXT* ctx,
 									unsigned char* iv, unsigned char iv_length,
 									unsigned char* buffer, unsigned int buffer_length,
@@ -58,7 +58,7 @@ static int aes_ccm_compute_unencrypted_tag(
  * @param output_size The size of the decrypted result
  * @return TRUE if result can be trusted, FALSE otherwise
  */
-int decrypt_key(datum_aes_ccm_t* input, unsigned char* key, void** output, unsigned int* output_size)
+int decrypt_key(datum_mbedtls_aes_ccm_t* input, unsigned char* key, void** output, unsigned int* output_size)
 {
 	// Check parameters
 	if(!input || !key || !output || !output_size)
@@ -67,7 +67,7 @@ int decrypt_key(datum_aes_ccm_t* input, unsigned char* key, void** output, unsig
 	
 	AES_CONTEXT ctx;
 	unsigned int header_size = 0;
-	unsigned char* aes_input_buffer = NULL;
+	unsigned char* mbedtls_aes_input_buffer = NULL;
 	unsigned int input_size = 0;
 	
 	uint8_t mac_first [AUTHENTICATOR_LENGTH];
@@ -88,8 +88,8 @@ int decrypt_key(datum_aes_ccm_t* input, unsigned char* key, void** output, unsig
 	/*
 	 * The aes input buffer is data to decrypt
 	 */
-	aes_input_buffer = xmalloc(*output_size);
-	memcpy(aes_input_buffer, (unsigned char*)input + header_size, *output_size);  
+	mbedtls_aes_input_buffer = xmalloc(*output_size);
+	memcpy(mbedtls_aes_input_buffer, (unsigned char*)input + header_size, *output_size);  
 	
 	/*
 	 * Get the MAC
@@ -108,18 +108,18 @@ int decrypt_key(datum_aes_ccm_t* input, unsigned char* key, void** output, unsig
 	 * Decrypt the input buffer now
 	 * NOTE: The 0xc is the nonce length (hardcoded)
 	 */
-	xprintf(L_DEBUG, "}--------[ Data passed to aes_ccm_encrypt_decrypt ]--------{\n");
+	xprintf(L_DEBUG, "}--------[ Data passed to mbedtls_aes_ccm_encrypt_decrypt ]--------{\n");
 	xprintf(L_DEBUG, "-- Nonce:\n");
 	hexdump(L_DEBUG, input->nonce, 0xc);
 	xprintf(L_DEBUG, "-- Input buffer:\n");
-	hexdump(L_DEBUG, aes_input_buffer, input_size);
+	hexdump(L_DEBUG, mbedtls_aes_input_buffer, input_size);
 	xprintf(L_DEBUG, "-- MAC:\n");
 	hexdump(L_DEBUG, mac_first, AUTHENTICATOR_LENGTH);
 	xprintf(L_DEBUG, "}----------------------------------------------------------{\n");
 	
-	aes_ccm_encrypt_decrypt(&ctx, input->nonce, 0xc, aes_input_buffer, input_size, mac_first, AUTHENTICATOR_LENGTH, (unsigned char*) *output);
+	mbedtls_aes_ccm_encrypt_decrypt(&ctx, input->nonce, 0xc, mbedtls_aes_input_buffer, input_size, mac_first, AUTHENTICATOR_LENGTH, (unsigned char*) *output);
 	
-	xfree(aes_input_buffer);
+	xfree(mbedtls_aes_input_buffer);
 	
 	
 	
@@ -127,7 +127,7 @@ int decrypt_key(datum_aes_ccm_t* input, unsigned char* key, void** output, unsig
 	 * Compute to check decryption
 	 */
 	memset(mac_second, 0, AUTHENTICATOR_LENGTH);
-	aes_ccm_compute_unencrypted_tag(&ctx, input->nonce, 0xc, (unsigned char*) *output, *output_size, mac_second);
+	mbedtls_aes_ccm_compute_unencrypted_tag(&ctx, input->nonce, 0xc, (unsigned char*) *output, *output_size, mac_second);
 	
 	
 	memset(&ctx, 0, sizeof(AES_CONTEXT));
@@ -171,7 +171,7 @@ int decrypt_key(datum_aes_ccm_t* input, unsigned char* key, void** output, unsig
  * @param output Decrypted result
  * @return TRUE if result can be trusted, FALSE otherwise
  */
-static int aes_ccm_encrypt_decrypt(
+static int mbedtls_aes_ccm_encrypt_decrypt(
 					 AES_CONTEXT* ctx,
 					 unsigned char* nonce, unsigned char nonce_length,
 					 unsigned char* input, unsigned int  input_length,
@@ -182,7 +182,7 @@ static int aes_ccm_encrypt_decrypt(
 	if(!ctx || !input || !mac || !output)
 		return FALSE;
 	
-	xprintf(L_INFO, "Entering aes_ccm_encrypt_decrypt...\n");
+	xprintf(L_INFO, "Entering mbedtls_aes_ccm_encrypt_decrypt...\n");
 	
 	unsigned char iv[16];
 	unsigned int loop = 0;
@@ -277,7 +277,7 @@ static int aes_ccm_encrypt_decrypt(
 	memset(iv, 0, sizeof(iv));
 	memset(tmp_buf, 0, sizeof(tmp_buf));
 	
-	xprintf(L_INFO, "Ending aes_ccm_encrypt_decrypt successfully!\n");
+	xprintf(L_INFO, "Ending mbedtls_aes_ccm_encrypt_decrypt successfully!\n");
 	
 	return TRUE;
 }
@@ -294,7 +294,7 @@ static int aes_ccm_encrypt_decrypt(
  * @param mac MAC result to use to validate decryption
  * @return TRUE if result can be trusted, FALSE otherwise
  */
-static int aes_ccm_compute_unencrypted_tag(
+static int mbedtls_aes_ccm_compute_unencrypted_tag(
 									AES_CONTEXT* ctx,
 									unsigned char* nonce, unsigned char nonce_length,
 									unsigned char* buffer, unsigned int buffer_length,
@@ -304,7 +304,7 @@ static int aes_ccm_compute_unencrypted_tag(
 	if(!ctx || !buffer || !mac || nonce_length > 0xe)
 		return FALSE;
 	
-	xprintf(L_INFO, "Entering aes_ccm_compute_unencrypted_tag...\n");
+	xprintf(L_INFO, "Entering mbedtls_aes_ccm_compute_unencrypted_tag...\n");
 	
 	unsigned char iv[AUTHENTICATOR_LENGTH];
 	unsigned int loop = 0;
@@ -365,7 +365,7 @@ static int aes_ccm_compute_unencrypted_tag(
 	
 	memset(iv, 0, AUTHENTICATOR_LENGTH);
 	
-	xprintf(L_INFO, "Ending aes_ccm_compute_unencrypted_tag successfully!\n");
+	xprintf(L_INFO, "Ending mbedtls_aes_ccm_compute_unencrypted_tag successfully!\n");
 	
 	return TRUE;
 }

--- a/src/encryption/decrypt.h
+++ b/src/encryption/decrypt.h
@@ -36,7 +36,7 @@
 /*
  * Prototypes
  */
-int decrypt_key(datum_aes_ccm_t* input, unsigned char* key, void** output, unsigned int* output_size);
+int decrypt_key(datum_mbedtls_aes_ccm_t* input, unsigned char* key, void** output, unsigned int* output_size);
 
 int decrypt_sector(dis_iodata_t* global_data, uint8_t* sector, off_t sector_address, uint8_t* buffer);
 

--- a/src/metadata/datums.c
+++ b/src/metadata/datums.c
@@ -365,17 +365,17 @@ void print_datum_use_key(LEVELS level, void* vdatum)
 	xprintf(level, "   ---------------------------\n");
 }
 
-void print_datum_aes_ccm(LEVELS level, void* vdatum)
+void print_datum_mbedtls_aes_ccm(LEVELS level, void* vdatum)
 {
-	datum_aes_ccm_t* datum = (datum_aes_ccm_t*) vdatum;
+	datum_mbedtls_aes_ccm_t* datum = (datum_mbedtls_aes_ccm_t*) vdatum;
 	
 	xprintf(level, "Nonce: \n");
 	print_nonce(level, datum->nonce);
 	xprintf(level, "MAC: \n");
 	print_mac(level, datum->mac);
 	xprintf(level, "Payload:\n");
-	hexdump(level, (void*)((char*)datum + sizeof(datum_aes_ccm_t)),
-			datum->header.datum_size - sizeof(datum_aes_ccm_t));
+	hexdump(level, (void*)((char*)datum + sizeof(datum_mbedtls_aes_ccm_t)),
+			datum->header.datum_size - sizeof(datum_mbedtls_aes_ccm_t));
 }
 
 void print_datum_tpmenc(LEVELS level, void* vdatum)

--- a/src/metadata/datums.h
+++ b/src/metadata/datums.h
@@ -165,12 +165,12 @@ typedef struct _datum_use_key
 
 
 /* Datum type = 5 */
-typedef struct _datum_aes_ccm
+typedef struct _datum_mbedtls_aes_ccm
 {
 	datum_header_safe_t header;
 	uint8_t nonce[12];
 	uint8_t mac[16];
-} datum_aes_ccm_t;
+} datum_mbedtls_aes_ccm_t;
 
 
 /* Datum type = 6 */
@@ -319,7 +319,7 @@ void print_datum_key(LEVELS level, void* vdatum);
 void print_datum_unicode(LEVELS level, void* vdatum);
 void print_datum_stretch_key(LEVELS level, void* vdatum);
 void print_datum_use_key(LEVELS level, void* vdatum);
-void print_datum_aes_ccm(LEVELS level, void* vdatum);
+void print_datum_mbedtls_aes_ccm(LEVELS level, void* vdatum);
 void print_datum_tpmenc(LEVELS level, void* vdatum);
 void print_datum_vmk(LEVELS level, void* vdatum);
 void print_datum_external(LEVELS level, void* vdatum);
@@ -346,7 +346,7 @@ static const print_datum_f print_datum_tab[NB_DATUM_TYPES] =
 	print_datum_unicode,
 	print_datum_stretch_key,
 	print_datum_use_key,
-	print_datum_aes_ccm,
+	print_datum_mbedtls_aes_ccm,
 	print_datum_tpmenc,
 	print_datum_generic,
 	print_datum_vmk,

--- a/src/metadata/fvek.c
+++ b/src/metadata/fvek.c
@@ -71,7 +71,7 @@ int get_fvek(bitlocker_dataset_t* dataset, void* vmk_datum, void** fvek_datum)
 	}
 	
 	/* Finally decrypt the FVEK with the VMK */
-	if(!decrypt_key((datum_aes_ccm_t*)*fvek_datum, vmk_key, fvek_datum, &fvek_size))
+	if(!decrypt_key((datum_mbedtls_aes_ccm_t*)*fvek_datum, vmk_key, fvek_datum, &fvek_size))
 	{
 		if(*fvek_datum)
 		{

--- a/src/metadata/vmk.c
+++ b/src/metadata/vmk.c
@@ -93,7 +93,7 @@ int get_vmk_from_clearkey(bitlocker_dataset_t* dataset, void** vmk_datum)
 	}
 	
 	/* Run the decryption */
-	result = get_vmk((datum_aes_ccm_t*)aesccm_datum, recovery_key, rk_size, (datum_key_t**)vmk_datum);
+	result = get_vmk((datum_mbedtls_aes_ccm_t*)aesccm_datum, recovery_key, rk_size, (datum_key_t**)vmk_datum);
 	
 	xfree(recovery_key);
 	
@@ -111,7 +111,7 @@ int get_vmk_from_clearkey(bitlocker_dataset_t* dataset, void** vmk_datum)
  * @param vmk The found datum_key_t containing the decrypted VMK
  * @return TRUE if result can be trusted, FALSE otherwise
  */
-int get_vmk(datum_aes_ccm_t* vmk_datum, uint8_t* recovery_key, size_t key_size, datum_key_t** vmk)
+int get_vmk(datum_mbedtls_aes_ccm_t* vmk_datum, uint8_t* recovery_key, size_t key_size, datum_key_t** vmk)
 {
 	// Check parameters
 	if(!vmk_datum || !recovery_key || key_size == 0)
@@ -126,7 +126,7 @@ int get_vmk(datum_aes_ccm_t* vmk_datum, uint8_t* recovery_key, size_t key_size, 
 	hexdump(L_DEBUG, recovery_key, key_size);
 	xprintf(L_DEBUG, "==========================================================\n");
 	
-	if(!decrypt_key((datum_aes_ccm_t*)vmk_datum, recovery_key, (void**)vmk, &vmk_size))
+	if(!decrypt_key((datum_mbedtls_aes_ccm_t*)vmk_datum, recovery_key, (void**)vmk, &vmk_size))
 	{
 		if(*vmk)
 		{

--- a/src/metadata/vmk.h
+++ b/src/metadata/vmk.h
@@ -39,7 +39,7 @@ int get_vmk_datum_from_guid(void* dataset, guid_t guid, void** vmk_datum);
 
 int get_vmk_datum_from_range(void* dataset, uint16_t min_range, uint16_t max_range, void** vmk_datum);
 
-int get_vmk(datum_aes_ccm_t* vmk_datum, uint8_t* recovery_key,
+int get_vmk(datum_mbedtls_aes_ccm_t* vmk_datum, uint8_t* recovery_key,
             size_t key_size, datum_key_t** vmk);
 
 

--- a/src/ssl_bindings.h
+++ b/src/ssl_bindings.h
@@ -24,22 +24,19 @@
 #define SSL_BINDINGS_H
 
 /*
- * Here stand the bindings for polarssl SHA256/SHA2/SHA-2 function for dislocker
+ * Here stand the bindings for mbedtls SHA256/SHA2/SHA-2 function for dislocker
  */
-#include "polarssl/config.h"
-#if defined(POLARSSL_SHA256_C)
-#define SHA256(input, len, output)       sha256(input, len, output, 0)
-#else
-#define SHA256(input, len, output)       sha2(input, len, output, 0)
-#endif
+#define SHA256(input, len, output)       mbedtls_sha256(input, len, output, 0)
 
 /* Here stand the bindings for AES functions and contexts */
-#define AES_CONTEXT                      aes_context
-#define AES_SETENC_KEY(ctx, key, size)   aes_setkey_enc(ctx, key, size)
-#define AES_SETDEC_KEY(ctx, key, size)   aes_setkey_dec(ctx, key, size)
-#define AES_ECB_ENC(ctx, mode, in, out)  aes_crypt_ecb(ctx, mode, in, out)
+#define AES_ENCRYPT                      MBEDTLS_AES_ENCRYPT
+#define AES_DECRYPT                      MBEDTLS_AES_DECRYPT
+#define AES_CONTEXT                      mbedtls_aes_context
+#define AES_SETENC_KEY(ctx, key, size)   mbedtls_aes_setkey_enc(ctx, key, size)
+#define AES_SETDEC_KEY(ctx, key, size)   mbedtls_aes_setkey_dec(ctx, key, size)
+#define AES_ECB_ENC(ctx, mode, in, out)  mbedtls_aes_crypt_ecb(ctx, mode, in, out)
 #define AES_CBC(ctx, mode, size, iv, in, out) \
-                                         aes_crypt_cbc(ctx, mode, size, iv, in, out);
+                                         mbedtls_aes_crypt_cbc(ctx, mode, size, iv, in, out);
 
 
 


### PR DESCRIPTION
Fedora / dnf does not allow to install polarssl from normal repositories -> "install polarssl" installs mbedtls instead. Missing polarssl breaks make.
Therefore, I replaced all polarssl hooks for the correct ones of mbedtls:
import polarssl/*  =>  import mbedtls/*
aes_*   =>   mbedtls_aes_
polarssl/sha2.h was dropped, since I could not find a suitable replacement within mbedtls.
Furthermore, AES_ENCRYPT and AES_DECRYPT have different names in mbedtls (MBEDTLS_AES_*)
This was solved via define in ssl_bindings.h

I only needed dislocker to work with FUSE to access a bitlocker-partition, so I didn't test it rigorously.
The current dislocker-version within the Fedora/dnf repos does not support fuse.