### PR TITLE
Honor DESTDIR environment variable during installation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -229,8 +229,8 @@ else()
 	set (BIN_FIND true)
 endif()
 
-install (CODE "execute_process (COMMAND ${CMAKE_COMMAND} -E create_symlink ${BIN_FUSE} \"${bindir}/${PROJECT_NAME}\")")
-install (CODE "execute_process (COMMAND ${CMAKE_COMMAND} -E create_symlink ${BIN_FUSE}.1.gz \"${mandir}/man1/${PROJECT_NAME}.1.gz\")")
+install (CODE "execute_process (COMMAND ${CMAKE_COMMAND} -E create_symlink ${BIN_FUSE} \"\$ENV{DESTDIR}${bindir}/${PROJECT_NAME}\")")
+install (CODE "execute_process (COMMAND ${CMAKE_COMMAND} -E create_symlink ${BIN_FUSE}.1.gz \"\$ENV{DESTDIR}${mandir}/man1/${PROJECT_NAME}.1.gz\")")
 
 set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${CLEAN_FILES}")
 


### PR DESCRIPTION
Honor DESTDIR environment variable during installation, see also #54 and below:

    failed to create symbolic link '/usr/bin/dislocker': Permission denied
    failed to create symbolic link '/usr/share/man/man1/dislocker.1.gz': Permission denied