### PR TITLE
Include limits.h to avoid "error: 'UINT_MAX' undeclared" during build

### DIFF
--- a/src/metadata/fvek.c
+++ b/src/metadata/fvek.c
@@ -21,6 +21,7 @@
  * USA.
  */
 
+#include <limits.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/src/metadata/vmk.c
+++ b/src/metadata/vmk.c
@@ -22,6 +22,7 @@
  */
 
 
+#include <limits.h>
 #include "dislocker/encryption/decrypt.h"
 #include "dislocker/metadata/vmk.h"
 


### PR DESCRIPTION
Include limits.h to avoid "error: 'UINT_MAX' undeclared" during build