### PR TITLE
Avoid "error: expected declaration specifiers or '...' before 'off_t'

### DIFF
--- a/include/dislocker/dislocker.h
+++ b/include/dislocker/dislocker.h
@@ -24,6 +24,7 @@
 #define DISLOCKER_MAIN_H
 
 #include <stdint.h>
+#include <sys/types.h>
 #include "dislocker/xstd/xstdio.h" // Only for off_t
 
 

--- a/include/dislocker/encryption/decrypt.h
+++ b/include/dislocker/encryption/decrypt.h
@@ -27,6 +27,7 @@
 #define AUTHENTICATOR_LENGTH 16
 
 
+#include <sys/types.h>
 #include "dislocker/xstd/xstdio.h" // Only for off_t
 #include "dislocker/encryption/encommon.h"
 


### PR DESCRIPTION
Avoid "error: expected declaration specifiers or '...' before 'off_t'" build failure on RHEL 5