### PR TITLE
Change CMakeLists.txt DIS_MAN location to use ${PROJECT_SOURCE_DIR}

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -149,7 +149,7 @@ if(NOT DEFINED bindir)
 endif()
 
 string (TOLOWER "${CMAKE_SYSTEM_NAME}" SYSNAME)
-set (DIS_MAN ../man/${SYSNAME})
+set (DIS_MAN ${PROJECT_SOURCE_DIR}/man/${SYSNAME})
 
 # RPATH handling
 if(POLICY CMP0042)


### PR DESCRIPTION
In order to compile a deb package the debuild tool creates a separate build directory and the relative path ".." no longer has any meaning. If src/CMakeLists.txt is changed to use the cmake variable  ${PROJECT_SOURCE_DIR} when setting DIS_MAN a package can build without issues as a debian package as well as in the way described in INSTALL.md