### PR TITLE
Small update to install document for Ubuntu and Debian

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,9 +17,13 @@ You need:
 If you have Ruby headers, the library will compile with some Ruby bindings and
 another program - see the NOTE section below - will be available.
 
-For Debian-like:
+For Debian-like distos based on Debian Jessie or Ubuntu 14.04 or older:
 
 - `aptitude install gcc cmake make libfuse-dev libpolarssl-dev ruby-dev`
+
+For Debian-like distos based on Debian Stretch or Ubuntu 16.04 or later:
+
+- `aptitude install gcc cmake make libfuse-dev libmbedtls-dev ruby-dev`
 
 For Fedora-like:
 


### PR DESCRIPTION
Update _INSTALL.md_  to more accurately reflect the development library install strings that will be needed with the different versions of Ubuntu and Debian based distributions.