### PR TITLE
non-relative man path needed for when build path is relocated

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -149,7 +149,7 @@ if(NOT DEFINED bindir)
 endif()
 
 string (TOLOWER "${CMAKE_SYSTEM_NAME}" SYSNAME)
-set (DIS_MAN ../man/${SYSNAME})
+set (DIS_MAN ${PROJECT_SOURCE_DIR}/man/${SYSNAME})
 
 # RPATH handling
 if(POLICY CMP0042)


### PR DESCRIPTION
When cmake is run outside of .`/src`, the path to the manpages source will be incorrect, so `PROJECT_SOURCE_DIR` or some other variable should be used in place of `..`