### PR TITLE
Support for Ubuntu 18.04 / ruby 2.5

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -111,3 +111,9 @@ instance, if you want to compile dislocker-fuse only, you'd simply run:
 $ cmake .
 $ make dislocker-fuse
 ```
+## A note on Ubuntu 18.04 / Ruby 2.5
+
+By an unknown reason, one ruby incude file needs to be copied before running cmake and make:
+```bash
+sudo cp /usr/include/x86_64-linux-gnu/ruby-2.5.0/ruby/config.h /usr/include/ruby-2.5.0/ruby/
+```

--- a/cmake/FindRuby.cmake
+++ b/cmake/FindRuby.cmake
@@ -13,7 +13,7 @@ if(RUBY_FOUND)
 endif()
 
 find_program(RUBY_EXECUTABLE
-  NAMES ruby2.2 ruby22 ruby2.1 ruby21 ruby2.0 ruby2 ruby1.9.3 ruby193 ruby1.9.2 ruby192 ruby1.9.1 ruby191 ruby1.9 ruby19 ruby1.8 ruby18 ruby
+  NAMES ruby2.5 ruby25 ruby2.4 ruby24 ruby2-3 rubu23 ruby2.2 ruby22 ruby2.1 ruby21 ruby2.0 ruby2 ruby1.9.3 ruby193 ruby1.9.2 ruby192 ruby1.9.1 ruby191 ruby1.9 ruby19 ruby1.8 ruby18 ruby
   PATHS /usr/bin /usr/local/bin /usr/pkg/bin
   )
 if(RUBY_EXECUTABLE)


### PR DESCRIPTION
Ubuntu comes with a newer version of Ruby and with a flaw for one include file.
This pull request tested successfully on Ubuntu 18.04