### PR TITLE
Fixed issues in Windows 10 1903 

### DIFF
--- a/include/dislocker/metadata/datums.h
+++ b/include/dislocker/metadata/datums.h
@@ -42,7 +42,7 @@
 /**
  * Here stand datums' value types stuff
  */
-#define NB_DATUMS_VALUE_TYPES 20
+#define NB_DATUMS_VALUE_TYPES 22
 
 enum value_types
 {
@@ -349,6 +349,8 @@ static const print_datum_f print_datum_tab[NB_DATUMS_VALUE_TYPES] =
 	print_datum_generic,
 	print_datum_generic,
 	print_datum_virtualization,
+	print_datum_generic,
+	print_datum_generic,
 	print_datum_generic,
 	print_datum_generic,
 	print_datum_generic,

--- a/src/inouts/inouts.c
+++ b/src/inouts/inouts.c
@@ -25,6 +25,7 @@
 #include "dislocker/inouts/inouts.priv.h"
 #include "dislocker/dislocker.priv.h"
 #include "dislocker/config.priv.h"
+#include <sys/mount.h>
 
 
 /**
@@ -87,6 +88,15 @@ static uint64_t get_volume_size(dis_context_t dis_ctx)
 
 		dis_free(input);
 	}
+
+	//Windows 10 1903 exFAT
+	if (!volume_size) {
+		uint64_t blksize64 = 0;
+		if(!ioctl(dis_ctx->io_data.volume_fd, BLKGETSIZE64, &blksize64)) {
+			volume_size = blksize64;
+		}
+	}
+	//Windows 10 1903 exFAT
 
 	return volume_size;
 }

--- a/src/metadata/datums.c
+++ b/src/metadata/datums.c
@@ -259,7 +259,8 @@ void print_one_datum(DIS_LOGS level, void* datum)
 
 	dis_datums_value_type_t value_type = header->value_type;
 
-	print_datum_tab[value_type](level, datum);
+	if (value_type < NB_DATUMS_VALUE_TYPES)
+		print_datum_tab[value_type](level, datum);
 }
 
 

--- a/src/metadata/metadata.c
+++ b/src/metadata/metadata.c
@@ -27,6 +27,7 @@
 #include "dislocker/metadata/metadata_config.h"
 #include "dislocker/metadata/print_metadata.h"
 #include "dislocker/dislocker.priv.h"
+#include <sys/mount.h>
 
 /*
  * On Darwin and FreeBSD, files are opened using 64 bits offsets/variables
@@ -159,6 +160,16 @@ int dis_metadata_initialize(dis_metadata_t dis_meta)
 		);
 		return DIS_RET_ERROR_VOLUME_HEADER_READ;
 	}
+
+	//Windows 10 1903 exFAT
+	if (!dis_meta->volume_header->sector_size) {
+		uint64_t nSectorSize = 0;
+		ioctl(dis_meta_cfg->fve_fd, BLKSSZGET, &nSectorSize);
+		if(!nSectorSize)
+			nSectorSize = 512;
+		dis_meta->volume_header->sector_size = (uint16_t)nSectorSize;
+	}
+	//Windows 10 1903 exFAT
 
 	/* For debug purpose, print the volume header retrieved */
 	print_volume_header(L_DEBUG, dis_meta);


### PR DESCRIPTION
Fixed an issue that dislocker corrupted when unlocking BitLocker drive created in Windows 10 1903.
Fixed an issue that it failed to unlock exFAT BitLocker drive created in Windows 10 1903.