### PR TITLE
Fixed NTFS volume size

### DIFF
--- a/src/inouts/inouts.c
+++ b/src/inouts/inouts.c
@@ -25,7 +25,9 @@
 #include "dislocker/inouts/inouts.priv.h"
 #include "dislocker/dislocker.priv.h"
 #include "dislocker/config.priv.h"
-#include <sys/mount.h>
+
+#include <sys/ioctl.h>
+#include <linux/fs.h>
 
 
 /**

--- a/src/inouts/inouts.c
+++ b/src/inouts/inouts.c
@@ -27,7 +27,8 @@
 #include "dislocker/config.priv.h"
 
 #include <sys/ioctl.h>
-#include <linux/fs.h>
+
+#define BLKGETSIZE64 _IOR(0x12,114,size_t)	/* return device size in bytes (u64 *arg) */
 
 
 /**

--- a/src/inouts/inouts.c
+++ b/src/inouts/inouts.c
@@ -84,6 +84,10 @@ static uint64_t get_volume_size(dis_context_t dis_ctx)
 
 		old_vbr = dis_metadata_set_volume_header(dis_ctx->metadata, input);
 		volume_size = dis_metadata_volume_size_from_vbr(dis_ctx->metadata);
+		//NTFS + 1 Sector
+		if (volume_size && memcmp(NTFS_SIGNATURE, dis_ctx->metadata->volume_header->signature, NTFS_SIGNATURE_SIZE) == 0)
+			volume_size += dis_ctx->metadata->volume_header->sector_size;
+		//NTFS + 1 Sector
 		dis_metadata_set_volume_header(dis_ctx->metadata, old_vbr);
 
 		dis_free(input);

--- a/src/metadata/metadata.c
+++ b/src/metadata/metadata.c
@@ -29,7 +29,8 @@
 #include "dislocker/dislocker.priv.h"
 
 #include <sys/ioctl.h>
-#include <linux/fs.h>
+
+#define BLKSSZGET  _IO(0x12,104)/* get block device sector size */
 
 /*
  * On Darwin and FreeBSD, files are opened using 64 bits offsets/variables

--- a/src/metadata/metadata.c
+++ b/src/metadata/metadata.c
@@ -27,7 +27,9 @@
 #include "dislocker/metadata/metadata_config.h"
 #include "dislocker/metadata/print_metadata.h"
 #include "dislocker/dislocker.priv.h"
-#include <sys/mount.h>
+
+#include <sys/ioctl.h>
+#include <linux/fs.h>
 
 /*
  * On Darwin and FreeBSD, files are opened using 64 bits offsets/variables


### PR DESCRIPTION
Fixed an issue that NTFS volume size was incorrect (one sector smaller) after the drive was unlocked.