### PR TITLE
Fixed the build error & Fixed an issue that NTFS volume size was incorrect

### DIFF
--- a/src/inouts/inouts.c
+++ b/src/inouts/inouts.c
@@ -25,7 +25,9 @@
 #include "dislocker/inouts/inouts.priv.h"
 #include "dislocker/dislocker.priv.h"
 #include "dislocker/config.priv.h"
-#include <sys/mount.h>
+
+#include <sys/ioctl.h>
+#include <linux/fs.h>
 
 
 /**

--- a/src/inouts/inouts.c
+++ b/src/inouts/inouts.c
@@ -27,7 +27,8 @@
 #include "dislocker/config.priv.h"
 
 #include <sys/ioctl.h>
-#include <linux/fs.h>
+
+#define BLKGETSIZE64 _IOR(0x12,114,size_t)	/* return device size in bytes (u64 *arg) */
 
 
 /**

--- a/src/inouts/inouts.c
+++ b/src/inouts/inouts.c
@@ -26,10 +26,6 @@
 #include "dislocker/dislocker.priv.h"
 #include "dislocker/config.priv.h"
 
-#include <sys/ioctl.h>
-
-#define BLKGETSIZE64 _IOR(0x12,114,size_t)	/* return device size in bytes (u64 *arg) */
-
 
 /**
  * Getting the real volume size is proving to be quite difficult.
@@ -87,23 +83,10 @@ static uint64_t get_volume_size(dis_context_t dis_ctx)
 
 		old_vbr = dis_metadata_set_volume_header(dis_ctx->metadata, input);
 		volume_size = dis_metadata_volume_size_from_vbr(dis_ctx->metadata);
-		//NTFS + 1 Sector
-		if (volume_size && memcmp(NTFS_SIGNATURE, dis_ctx->metadata->volume_header->signature, NTFS_SIGNATURE_SIZE) == 0)
-			volume_size += dis_ctx->metadata->volume_header->sector_size;
-		//NTFS + 1 Sector
 		dis_metadata_set_volume_header(dis_ctx->metadata, old_vbr);
 
 		dis_free(input);
 	}
-
-	//Windows 10 1903 exFAT
-	if (!volume_size) {
-		uint64_t blksize64 = 0;
-		if(!ioctl(dis_ctx->io_data.volume_fd, BLKGETSIZE64, &blksize64)) {
-			volume_size = blksize64;
-		}
-	}
-	//Windows 10 1903 exFAT
 
 	return volume_size;
 }

--- a/src/inouts/inouts.c
+++ b/src/inouts/inouts.c
@@ -84,6 +84,10 @@ static uint64_t get_volume_size(dis_context_t dis_ctx)
 
 		old_vbr = dis_metadata_set_volume_header(dis_ctx->metadata, input);
 		volume_size = dis_metadata_volume_size_from_vbr(dis_ctx->metadata);
+		//NTFS + 1 Sector
+		if (volume_size && memcmp(NTFS_SIGNATURE, dis_ctx->metadata->volume_header->signature, NTFS_SIGNATURE_SIZE) == 0)
+			volume_size += dis_ctx->metadata->volume_header->sector_size;
+		//NTFS + 1 Sector
 		dis_metadata_set_volume_header(dis_ctx->metadata, old_vbr);
 
 		dis_free(input);

--- a/src/inouts/prepare.c
+++ b/src/inouts/prepare.c
@@ -113,10 +113,9 @@ int prepare_crypt(dis_context_t dis_ctx)
 	io_data->nb_backup_sectors     = dis_metadata_backup_sectors_count(io_data->metadata);
 
 	/*
-	 * We need to grab the volume's size from the first sector, so we can
-	 * announce it on a getattr call
+	 * Get volume size directly from dis_metadata_t, which is more accurate.
 	 */
-	io_data->volume_size = dis_inouts_volume_size(dis_ctx);
+	io_data->volume_size = io_data->encrypted_volume_size;
 	if(io_data->volume_size == 0)
 	{
 		dis_printf(L_ERROR, "Can't initialize the volume's size\n");

--- a/src/metadata/metadata.c
+++ b/src/metadata/metadata.c
@@ -29,7 +29,8 @@
 #include "dislocker/dislocker.priv.h"
 
 #include <sys/ioctl.h>
-#include <linux/fs.h>
+
+#define BLKSSZGET  _IO(0x12,104)/* get block device sector size */
 
 /*
  * On Darwin and FreeBSD, files are opened using 64 bits offsets/variables

--- a/src/metadata/metadata.c
+++ b/src/metadata/metadata.c
@@ -27,7 +27,9 @@
 #include "dislocker/metadata/metadata_config.h"
 #include "dislocker/metadata/print_metadata.h"
 #include "dislocker/dislocker.priv.h"
-#include <sys/mount.h>
+
+#include <sys/ioctl.h>
+#include <linux/fs.h>
 
 /*
  * On Darwin and FreeBSD, files are opened using 64 bits offsets/variables


### PR DESCRIPTION
Fixed the build error on Mac OS
Fixed an issue that NTFS volume size was incorrect (one sector smaller) after the drive was unlocked.

