### PR TITLE
Dependency from libpolarssl-dev to libmbedtls-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 
 before_install:
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update -qq; fi
-    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -qq libfuse-dev libpolarssl-dev ruby-dev; fi
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -qq libfuse-dev libmbedtls-dev ruby-dev; fi
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install -v Caskroom/cask/osxfuse; fi
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./src/mbed_install.sh; fi


### PR DESCRIPTION
libpolarssl-dev no longer exists in Ubuntu (or Debian generally)
replaced with libmbedtls-dev in ~ 2016.

See also
https://github.com/Aorimn/dislocker/issues/76
https://github.com/Aorimn/dislocker/issues/194#issuecomment-533793440
https://github.com/Aorimn/dislocker/issues/188
