### PR TITLE
Fixed an error that "virtualization datum's" struct did not align by …

### DIFF
--- a/include/dislocker/metadata/extended_info.h
+++ b/include/dislocker/metadata/extended_info.h
@@ -32,6 +32,7 @@
  * This structure is new to Windows 8
  * It's the virtualization datum's payload
  */
+#pragma pack (1)
 typedef struct _extended_info {
 	uint16_t unknown1;
 	uint16_t size;
@@ -41,7 +42,12 @@ typedef struct _extended_info {
 	uint32_t convertlog_size;
 	uint32_t sector_size1;
 	uint32_t sector_size2;
+	uint32_t unknown3[6];
+	uint64_t FVE2_da392a22_addr;
+	uint32_t FVE2_da392a22_size;
+	uint32_t unknown4;
 } extended_info_t;
+#pragma pack ()
 
 
 

--- a/src/inouts/prepare.c
+++ b/src/inouts/prepare.c
@@ -109,6 +109,10 @@ int prepare_crypt(dis_context_t dis_ctx)
 	io_data->decrypt_region = read_decrypt_sectors;
 	io_data->encrypt_region = encrypt_write_sectors;
 	io_data->encrypted_volume_size = dis_metadata_encrypted_volume_size(io_data->metadata);
+	if (io_data->metadata->information->version == V_VISTA) {
+		io_data->encrypted_volume_size = dis_metadata_volume_size_from_vbr(dis_ctx->metadata);
+		io_data->encrypted_volume_size += io_data->sector_size;		//The volume size of Vista should include the DBR backup
+	}
 	io_data->backup_sectors_addr   = dis_metadata_ntfs_sectors_address(io_data->metadata);
 	io_data->nb_backup_sectors     = dis_metadata_backup_sectors_count(io_data->metadata);
 

--- a/src/metadata/metadata.c
+++ b/src/metadata/metadata.c
@@ -1159,7 +1159,7 @@ void dis_metadata_vista_vbr_fve2ntfs(dis_metadata_t dis_meta, void* vbr)
 	memcpy(volume_header->signature, NTFS_SIGNATURE, NTFS_SIGNATURE_SIZE);
 
 	/* And this is for the MFT Mirror field */
-	volume_header->mft_mirror = dis_meta->volume_header->mft_mirror;
+	volume_header->mft_mirror = dis_metadata_mftmirror(dis_meta);
 }
 
 


### PR DESCRIPTION
Fixed an error that "virtualization datum's" struct did not align by bytes.
Fixed an error that relates to the support of BitLocker created by Windows Vista.