### PR TITLE
fix: Make compatible with macOS 12 Monterey & mbedtls 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ Makefile
 cmake_install.cmake
 cmake_uninstall.cmake
 install_manifest.txt
+
+# macOS produced files
+*.dylib
+*.bundle

--- a/cmake/FindPolarSSL.cmake
+++ b/cmake/FindPolarSSL.cmake
@@ -51,7 +51,7 @@ endif()
 
 if( NOT CMAKE_CROSSCOMPILING )
   execute_process(
-    COMMAND echo "#include <${POLARSSL_INC_FOLDER}/version.h>\n#include <stdio.h>\nint main(){printf(${POLARSSL_REAL_NAME}_VERSION_STRING);return 0;}"
+    COMMAND echo "#include <${POLARSSL_INC_FOLDER}/build_info.h>\n#include <stdio.h>\nint main(){printf(${POLARSSL_REAL_NAME}_VERSION_STRING);return 0;}"
     OUTPUT_FILE a.c
   )
   execute_process(
@@ -66,7 +66,7 @@ if( NOT CMAKE_CROSSCOMPILING )
   )
 else()
   execute_process(
-    COMMAND grep -w "MBEDTLS_VERSION_STRING" ${POLARSSL_INCLUDE_DIRS}/${POLARSSL_INC_FOLDER}/version.h
+    COMMAND grep -w "MBEDTLS_VERSION_STRING" ${POLARSSL_INCLUDE_DIRS}/${POLARSSL_INC_FOLDER}/build_info.h
     COMMAND sed -e "s@\s\+@ @g"
     COMMAND cut -d\  -f3
     COMMAND sed -e "s@\"@@g"

--- a/include/dislocker/ssl_bindings.h.in
+++ b/include/dislocker/ssl_bindings.h.in
@@ -26,18 +26,13 @@
 /*
  * Here stand the bindings for polarssl SHA256/SHA2/SHA-2 function for dislocker
  */
-#include "@POLARSSL_INC_FOLDER@/config.h"
-#include "@POLARSSL_INC_FOLDER@/version.h"
+#include "@POLARSSL_INC_FOLDER@/build_info.h"
 #include "@POLARSSL_INC_FOLDER@/aes.h"
 
 // Function's name changed
 #if defined(MBEDTLS_SHA256_C)
 #  include "mbedtls/sha256.h"
-#  if MBEDTLS_VERSION_NUMBER >= 0x02070000
-#    define SHA256(input, len, output)         mbedtls_sha256_ret(input, len, output, 0)
-#  else
-#    define SHA256(input, len, output)         mbedtls_sha256(input, len, output, 0)
-#  endif /* POLARSSL_VERSION_NUMBER >= 0x02070000 */
+#  define SHA256(input, len, output)         mbedtls_sha256(input, len, output, 0)
 #else /* defined(MBEDTLS_SHA256_C) */
 
 #  if defined(POLARSSL_SHA256_C)


### PR DESCRIPTION
Various patches that make this work with the latest libraries, and specifically macOS 12 Monterey.
Confirmed by running:

```

brew install --cask macfuse

xcode-select --install

export CPATH=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include

make .

make

sudo make install