### PR TITLE
Minor out of bounds reads and use after free fixes

### DIFF
--- a/include/dislocker/metadata/datums.h
+++ b/include/dislocker/metadata/datums.h
@@ -42,7 +42,7 @@
 /**
  * Here stand datums' value types stuff
  */
-#define NB_DATUMS_VALUE_TYPES 22
+#define NB_DATUMS_VALUE_TYPES 20
 
 enum value_types
 {
@@ -349,8 +349,6 @@ static const print_datum_f print_datum_tab[NB_DATUMS_VALUE_TYPES] =
 	print_datum_generic,
 	print_datum_generic,
 	print_datum_virtualization,
-	print_datum_generic,
-	print_datum_generic,
 	print_datum_generic,
 	print_datum_generic,
 	print_datum_generic,

--- a/src/dislocker-fuse.c
+++ b/src/dislocker-fuse.c
@@ -199,6 +199,8 @@ int main(int argc, char** argv)
 	/* Get command line options */
 	dis_ctx = dis_new();
 	param_idx = dis_getopts(dis_ctx, argc, argv);
+	if (param_idx == -1)
+		exit(EXIT_FAILURE);
 
 	/*
 	 * Check we have a volume path given and if not, take the first non-argument

--- a/src/metadata/datums.c
+++ b/src/metadata/datums.c
@@ -229,7 +229,7 @@ int get_payload_safe(void* data, void** payload, size_t* size_payload)
 	if(!get_header_safe(data, &header))
 		return FALSE;
 
-	if(header.value_type > NB_DATUMS_VALUE_TYPES)
+	if(header.value_type >= NB_DATUMS_VALUE_TYPES)
 		return FALSE;
 
 	size_header = datum_value_types_prop[header.value_type].size_header;
@@ -662,7 +662,7 @@ int get_nested_datum(void* datum, void** datum_nested)
 	if(!get_header_safe(datum, &header))
 		return FALSE;
 
-	if(header.value_type > NB_DATUMS_VALUE_TYPES)
+	if(header.value_type >= NB_DATUMS_VALUE_TYPES)
 		return FALSE;
 
 	if(!datum_value_types_prop[header.value_type].has_nested_datum)


### PR DESCRIPTION
Hi, I noticed a segfault when using dislocker on fedora 36 and it seems some changed default compiler flags 
has made the runtime more sensitive to memory over/under reads. I compiled with -fsanitize=address,undefined and re-ran my tests which made it easier to spot the errors (see the individual commit messages for the sanitizer dumps).

I tested these fixes mounting an bitlocker image without it crashing but I am not familiar with this code base so I might have messed something up. 

Thanks for this project btw!