### PR TITLE
Fix for macOS build failing on Monterey (#278)

### DIFF
--- a/cmake/FindPolarSSL.cmake
+++ b/cmake/FindPolarSSL.cmake
@@ -49,6 +49,10 @@ if( ${POLARSSL_LIBRARIES-NOTFOUND} )
   return()
 endif()
 
+if( "${CMAKE_C_COMPILER}" STREQUAL "/Library/Developer/CommandLineTools/usr/bin/cc" )
+  set(CMAKE_C_COMPILER cc)
+endif()
+
 if( NOT CMAKE_CROSSCOMPILING )
   execute_process(
     COMMAND echo "#include <${POLARSSL_INC_FOLDER}/version.h>\n#include <stdio.h>\nint main(){printf(${POLARSSL_REAL_NAME}_VERSION_STRING);return 0;}"


### PR DESCRIPTION
Fixed an issue in cmake/FindPolarSSL.cmake where the system's
C compiler would be called directly without the shim to provide
access to standard system libraries. With this fix, building
on macOS no longer fails to find stdio.h ;)