### PR TITLE
Revert "fix: Make compatible with macOS 12 Monterey & mbedtls 3"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,3 @@ Makefile
 cmake_install.cmake
 cmake_uninstall.cmake
 install_manifest.txt
-
-# macOS produced files
-*.dylib
-*.bundle

--- a/cmake/FindPolarSSL.cmake
+++ b/cmake/FindPolarSSL.cmake
@@ -55,7 +55,7 @@ endif()
 
 if( NOT CMAKE_CROSSCOMPILING )
   execute_process(
-    COMMAND echo "#include <${POLARSSL_INC_FOLDER}/build_info.h>\n#include <stdio.h>\nint main(){printf(${POLARSSL_REAL_NAME}_VERSION_STRING);return 0;}"
+    COMMAND echo "#include <${POLARSSL_INC_FOLDER}/version.h>\n#include <stdio.h>\nint main(){printf(${POLARSSL_REAL_NAME}_VERSION_STRING);return 0;}"
     OUTPUT_FILE a.c
   )
   execute_process(
@@ -70,7 +70,7 @@ if( NOT CMAKE_CROSSCOMPILING )
   )
 else()
   execute_process(
-    COMMAND grep -w "MBEDTLS_VERSION_STRING" ${POLARSSL_INCLUDE_DIRS}/${POLARSSL_INC_FOLDER}/build_info.h
+    COMMAND grep -w "MBEDTLS_VERSION_STRING" ${POLARSSL_INCLUDE_DIRS}/${POLARSSL_INC_FOLDER}/version.h
     COMMAND sed -e "s@\s\+@ @g"
     COMMAND cut -d\  -f3
     COMMAND sed -e "s@\"@@g"

--- a/include/dislocker/ssl_bindings.h.in
+++ b/include/dislocker/ssl_bindings.h.in
@@ -26,13 +26,18 @@
 /*
  * Here stand the bindings for polarssl SHA256/SHA2/SHA-2 function for dislocker
  */
-#include "@POLARSSL_INC_FOLDER@/build_info.h"
+#include "@POLARSSL_INC_FOLDER@/config.h"
+#include "@POLARSSL_INC_FOLDER@/version.h"
 #include "@POLARSSL_INC_FOLDER@/aes.h"
 
 // Function's name changed
 #if defined(MBEDTLS_SHA256_C)
 #  include "mbedtls/sha256.h"
-#  define SHA256(input, len, output)         mbedtls_sha256(input, len, output, 0)
+#  if MBEDTLS_VERSION_NUMBER >= 0x02070000
+#    define SHA256(input, len, output)         mbedtls_sha256_ret(input, len, output, 0)
+#  else
+#    define SHA256(input, len, output)         mbedtls_sha256(input, len, output, 0)
+#  endif /* POLARSSL_VERSION_NUMBER >= 0x02070000 */
 #else /* defined(MBEDTLS_SHA256_C) */
 
 #  if defined(POLARSSL_SHA256_C)


### PR DESCRIPTION
Reverts Aorimn/dislocker#280 as per https://github.com/Aorimn/dislocker/issues/304

We'll need another fix that doesn't break linux builds.