### PR TITLE
Re-enable macOS building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ install_manifest.txt
 .DS_Store
 *.dylib
 *.bundle
+
+# Visual Studio Code
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ Makefile
 cmake_install.cmake
 cmake_uninstall.cmake
 install_manifest.txt
+
+# macOS produced files
+.DS_Store
+*.dylib
+*.bundle

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,6 +48,11 @@ For OSX: Follow the instructions in the next section.
 
 Note that the code expects at least FUSE 2.6.
 
+For macOS:
+
+Install HomeBrew https://brew.sh
+- `brew install cmake pkgconf mbedtls`
+
 # INSTALLING
 
 Each OS type has its own section below, beware to follow yours:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@ For Debian-like distros based on Debian Jessie or Ubuntu 14.04 or older:
 
 For Debian-like distros based on Debian Stretch or Ubuntu 16.04 or later:
 
-- `aptitude install gcc cmake make libfuse-dev libmbedtls-dev ruby-dev`
+- `aptitude install gcc cmake make libfuse-dev libmbedtls-dev ruby-dev pkgconf`
 
 For Fedora-like:
 

--- a/cmake/FindPolarSSL.cmake
+++ b/cmake/FindPolarSSL.cmake
@@ -53,6 +53,15 @@ if( "${CMAKE_C_COMPILER}" STREQUAL "/Library/Developer/CommandLineTools/usr/bin/
   set(CMAKE_C_COMPILER cc)
 endif()
 
+if(APPLE)
+  execute_process(
+    COMMAND xcrun --sdk macosx --show-sdk-path
+    OUTPUT_VARIABLE envSdkRoot
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  set(ENV{SDKROOT} "${envSdkRoot}")
+endif()
+
 if( NOT CMAKE_CROSSCOMPILING )
   execute_process(
     COMMAND echo "#include <${POLARSSL_INC_FOLDER}/version.h>\n#include <stdio.h>\nint main(){printf(${POLARSSL_REAL_NAME}_VERSION_STRING);return 0;}"

--- a/include/dislocker/ssl_bindings.h.in
+++ b/include/dislocker/ssl_bindings.h.in
@@ -26,8 +26,13 @@
 /*
  * Here stand the bindings for polarssl SHA256/SHA2/SHA-2 function for dislocker
  */
-#include "@POLARSSL_INC_FOLDER@/config.h"
 #include "@POLARSSL_INC_FOLDER@/version.h"
+#if MBEDTLS_VERSION_MAJOR >= 3
+#include "@POLARSSL_INC_FOLDER@/mbedtls_config.h"
+#include "@POLARSSL_INC_FOLDER@/compat-2.x.h"
+#else
+#include "@POLARSSL_INC_FOLDER@/config.h"
+#endif
 #include "@POLARSSL_INC_FOLDER@/aes.h"
 
 // Function's name changed


### PR DESCRIPTION
Main changes:

- Dynamically locate macOS SDK
- Add support for Mbed TLS 3

Tested building in macOS 12.6.9, 13.5.1 and Ubuntu 22.04.3.

