### PR TITLE
Fix use of File.exists removed with Ruby 3.2.0, fixes issue #298

### DIFF
--- a/src/dislocker-find.rb.in
+++ b/src/dislocker-find.rb.in
@@ -32,7 +32,7 @@ def get_partitions
 	uname = nil
 	reps = %w(/bin/ /usr/bin/ /sbin/ /usr/sbin/)
 	reps.each do |rep|
-		uname = "#{rep}uname" if File.exists?("#{rep}uname")
+		uname = "#{rep}uname" if File.exist?("#{rep}uname")
 	end
 
 	if uname.nil?
@@ -138,7 +138,7 @@ end
 
 encrypted_devices = []
 devices.each do |dev|
-	next unless File.exists? dev
+	next unless File.exist? dev
 	encrypted_devices << dev if is_bitlocker_encrypted? dev
 end
 


### PR DESCRIPTION
Method File.exists was deprecated with Ruby 2.2.0 and removed with Ruby 3.2.0 according to
https://www.reddit.com/r/ruby/comments/1196wti/psa_and_a_little_rant_fileexists_direxists/.