### PR TITLE
metadata: fallback linear scan for VIRTUALIZATION INFO datum beyond dataset copy_size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
 # USA.
 
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 3.5)
 project (dislocker C)
 
 set (AUTHOR "Romain Coltel")


### PR DESCRIPTION
Fixes https://github.com/Aorimn/dislocker/issues/334 https://github.com/Aorimn/dislocker/issues/343