### PR TITLE
Update INSTALL.md to include libfuse3-dev in required debian packages

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,7 @@ another program - see the NOTE section below - will be available.
 
 For Debian-like distros:
 
-- `aptitude install gcc cmake make libfuse-dev libmbedtls-dev ruby-dev pkgconf`
+- `aptitude install gcc cmake make libfuse-dev libmbedtls-dev ruby-dev pkgconf libfuse3-dev`
 
 For Fedora-like:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,7 @@ another program - see the NOTE section below - will be available.
 
 For Debian-like distros:
 
-- `aptitude install gcc cmake make libfuse-dev libmbedtls-dev ruby-dev pkgconf libfuse3-dev`
+- `aptitude install gcc cmake make libfuse3-dev libmbedtls-dev ruby-dev pkgconf`
 
 For Fedora-like:
 


### PR DESCRIPTION
Added 'libfuse3-dev' to the installation instructions for Debian-like distributions.

By the way, the instructions are excellent. Appreciated.