### PR TITLE
Fix macOS build and getopt crash

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -269,7 +269,7 @@ int dis_getopts(dis_context_t dis_ctx, int argc, char** argv)
 	int trueval = TRUE;
 
 
-	long_opts = malloc(nb_options * sizeof(struct option));
+	long_opts = calloc(nb_options + 1, sizeof(struct option));
 	while(nb_options--)
 	{
 		long_opts[nb_options].name    = dis_opt[nb_options].opt.name;
@@ -277,6 +277,7 @@ int dis_getopts(dis_context_t dis_ctx, int argc, char** argv)
 		long_opts[nb_options].flag    = dis_opt[nb_options].opt.flag;
 		long_opts[nb_options].val     = dis_opt[nb_options].opt.val;
 	}
+	/* long_opts[nb_options+1] is the required {NULL,0,NULL,0} sentinel, zeroed by calloc */
 
 
 	while((optchar = getopt_long(argc, argv, short_opts, long_opts, NULL)) != -1)

--- a/src/dislocker-fuse.c
+++ b/src/dislocker-fuse.c
@@ -54,8 +54,13 @@ dis_context_t dis_ctx;
 /**
  * Stubs used for FUSE operations.
  */
+#ifdef __APPLE__
+static int fs_getattr(const char *path, struct fuse_darwin_attr *stbuf,
+                      struct fuse_file_info *fi)
+#else
 static int fs_getattr(const char *path, struct stat *stbuf,
                       struct fuse_file_info *fi)
+#endif
 {
 	(void) fi;
 	int res = 0;
@@ -63,18 +68,29 @@ static int fs_getattr(const char *path, struct stat *stbuf,
 	if(!path || !stbuf)
 		return -EINVAL;
 
-	memset(stbuf, 0, sizeof(struct stat));
+	memset(stbuf, 0, sizeof(*stbuf));
 	if(strcmp(path, "/") == 0)
 	{
+#ifdef __APPLE__
+		stbuf->mode = S_IFDIR | 0555;
+		stbuf->nlink = 2;
+#else
 		stbuf->st_mode = S_IFDIR | 0555;
 		stbuf->st_nlink = 2;
+#endif
 	}
 	else if(strcmp(path, NTFS_FILERELATIVEPATH) == 0)
 	{
 		mode_t m = dis_is_read_only(dis_ctx) ? 0444 : 0666;
+#ifdef __APPLE__
+		stbuf->mode = S_IFREG | m;
+		stbuf->nlink = 1;
+		stbuf->size = (off_t)dis_inouts_volume_size(dis_ctx);
+#else
 		stbuf->st_mode = S_IFREG | m;
 		stbuf->st_nlink = 1;
 		stbuf->st_size = (off_t)dis_inouts_volume_size(dis_ctx);
+#endif
 	}
 	else
 		res = -ENOENT;
@@ -82,9 +98,15 @@ static int fs_getattr(const char *path, struct stat *stbuf,
 	return res;
 }
 
+#ifdef __APPLE__
+static int fs_readdir(const char *path, void *buf, fuse_darwin_fill_dir_t filler,
+                      off_t offset, struct fuse_file_info *fi,
+                      enum fuse_readdir_flags flags)
+#else
 static int fs_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
                       off_t offset, struct fuse_file_info *fi,
                       enum fuse_readdir_flags flags)
+#endif
 {
 	/* Both variables aren't used here */
 	(void) offset;


### PR DESCRIPTION
Summary:
- fix the macFUSE 3 Darwin callback signatures used by dislocker-fuse
- terminate the getopt_long option table correctly to avoid a help-path crash

Details:
On macOS, recent macFUSE headers use Darwin-specific callback signatures for getattr and readdir, so the existing Linux-style function pointers fail to compile. This change adds Apple-specific signatures and field access while preserving existing behavior on other platforms.

The option parsing code also built the long option table without the required trailing zero entry. getopt_long could then read past the end of the array and crash even on simple invocations like dislocker-fuse -h. Using calloc for one extra zeroed entry preserves the existing options and provides the required terminator.

Validation:
- make
- make travis-test